### PR TITLE
Build the new External Footer component using mocked data

### DIFF
--- a/packages/styles/scss/components/footer/_footer_external.scss
+++ b/packages/styles/scss/components/footer/_footer_external.scss
@@ -1,0 +1,138 @@
+@use '../../config' as *;
+@use '../../spacing' as *;
+@use '../../theme' as *;
+@use '../../type' as *;
+@use '../../breakpoint' as *;
+
+@mixin footer_external {
+  .#{$prefix}--footer-ext {
+    background-color: #1a4262; // TODO: Use the token $background-brand-dark
+    color: $text-on-color;
+    padding: $spacing-07 $spacing-03;
+  }
+
+  .#{$prefix}--footer-ext__content {
+    display: grid;
+    gap: $spacing-07;
+    grid-template-columns: 2fr 3fr;
+    padding-bottom: $spacing-05;
+
+    @include breakpoint-down(md) {
+      grid-template-columns: 1fr;
+    }
+  }
+
+  .#{$prefix}--footer-ext__content__corporate__logo {
+    align-items: center;
+    display: flex;
+  }
+
+  .#{$prefix}--footer-ext__content__corporate__logo__service {
+    @include type-style('productive-heading-03');
+
+    font-weight: 700; // TODO: Use the token
+    margin-left: $spacing-07;
+    text-transform: uppercase;
+  }
+
+  .#{$prefix}--footer-ext__content__corporate__address {
+    @include type-style('body-short-01');
+
+    margin-top: $spacing-05;
+  }
+
+  .#{$prefix}--footer-ext__content__corporate__social {
+    @include type-style('body-short-01');
+
+    margin-top: $spacing-06;
+  }
+
+  .#{$prefix}--footer-ext__content__corporate__social__list {
+    display: flex;
+    margin-top: $spacing-03;
+  }
+
+  .#{$prefix}--footer-ext__content__corporate__social__list__icon {
+    & + .#{$prefix}--footer-ext__content__corporate__social__list__icon {
+      margin-left: $spacing-03;
+    }
+
+    & a {
+      cursor: pointer;
+    }
+
+    // [1] Remove a small gap at the bottom of the svg that extends the <a> height
+    & svg {
+      fill: $text-on-color;
+      vertical-align: bottom; // [1]
+    }
+  }
+
+  .#{$prefix}--footer-ext__content__links {
+    display: grid;
+    gap: $spacing-07;
+    grid-template-columns: repeat(2, 1fr);
+
+    @include breakpoint-down(md) {
+      grid-template-columns: 1fr;
+    }
+  }
+
+  .#{$prefix}--footer-ext__content__links__column__title {
+    color: #36b5c5; // TODO: Use the token
+    font-weight: 700; // TODO: Use the token
+    text-transform: uppercase;
+  }
+
+  .#{$prefix}--footer-ext__content__links__column__nav-list {
+    margin-top: $spacing-05;
+
+    & > li {
+      font-weight: 600; // TODO: Use the token
+
+      & + li {
+        margin-top: $spacing-04;
+      }
+
+      & > a {
+        color: $text-on-color;
+
+        &:hover {
+          color: $text-on-color;
+        }
+      }
+    }
+  }
+
+  .#{$prefix}--footer-ext__legal {
+    @include type-style('body-short-01');
+
+    border-top: 1px solid rgba(255, 255, 255, 0.3); // TODO: use token
+    display: grid;
+    gap: $spacing-03;
+    grid-template-columns: 1fr max-content;
+    padding-top: $spacing-05;
+
+    @include breakpoint-down(md) {
+      grid-template-columns: 1fr;
+    }
+  }
+
+  .#{$prefix}--footer-ext__legal__nav__links {
+    display: flex;
+  }
+
+  .#{$prefix}--footer-ext__legal__nav__links__link {
+    & + .#{$prefix}--footer-ext__legal__nav__links__link {
+      margin-left: $spacing-07;
+    }
+
+    & > a {
+      color: $text-on-color;
+
+      &:hover {
+        color: $text-on-color;
+      }
+    }
+  }
+}

--- a/packages/styles/scss/components/footer/_footer_external.scss
+++ b/packages/styles/scss/components/footer/_footer_external.scss
@@ -22,12 +22,12 @@
     }
   }
 
-  .#{$prefix}--footer-ext__content__corporate__logo {
+  .#{$prefix}--footer-ext__branding {
     align-items: center;
     display: flex;
   }
 
-  .#{$prefix}--footer-ext__content__corporate__logo__service {
+  .#{$prefix}--footer-ext__product-name {
     @include type-style('productive-heading-03');
 
     font-weight: 700; // TODO: Use the token
@@ -35,25 +35,25 @@
     text-transform: uppercase;
   }
 
-  .#{$prefix}--footer-ext__content__corporate__address {
+  .#{$prefix}--footer-ext__address {
     @include type-style('body-short-01');
 
     margin-top: $spacing-05;
   }
 
-  .#{$prefix}--footer-ext__content__corporate__social {
+  .#{$prefix}--footer-ext__social-wrapper {
     @include type-style('body-short-01');
 
     margin-top: $spacing-06;
   }
 
-  .#{$prefix}--footer-ext__content__corporate__social__list {
+  .#{$prefix}--footer-ext__social-icons-list {
     display: flex;
     margin-top: $spacing-03;
   }
 
-  .#{$prefix}--footer-ext__content__corporate__social__list__icon {
-    & + .#{$prefix}--footer-ext__content__corporate__social__list__icon {
+  .#{$prefix}--footer-ext__social-icon {
+    & + .#{$prefix}--footer-ext__social-icon {
       margin-left: $spacing-03;
     }
 
@@ -68,7 +68,7 @@
     }
   }
 
-  .#{$prefix}--footer-ext__content__links {
+  .#{$prefix}--footer-ext__nav-wrapper {
     display: grid;
     gap: $spacing-07;
     grid-template-columns: repeat(2, 1fr);
@@ -78,28 +78,28 @@
     }
   }
 
-  .#{$prefix}--footer-ext__content__links__column__title {
+  .#{$prefix}--footer-ext__nav-title {
     color: #36b5c5; // TODO: Use the token
     font-weight: 700; // TODO: Use the token
     text-transform: uppercase;
   }
 
-  .#{$prefix}--footer-ext__content__links__column__nav-list {
+  .#{$prefix}--footer-ext__nav-list {
     margin-top: $spacing-05;
+  }
 
-    & > li {
-      font-weight: 600; // TODO: Use the token
+  .#{$prefix}--footer-ext__nav-link {
+    font-weight: 600; // TODO: Use the token
 
-      & + li {
-        margin-top: $spacing-04;
-      }
+    & + .#{$prefix}--footer-ext__nav-link {
+      margin-top: $spacing-04;
+    }
 
-      & > a {
+    & > a {
+      color: $text-on-color;
+
+      &:hover {
         color: $text-on-color;
-
-        &:hover {
-          color: $text-on-color;
-        }
       }
     }
   }
@@ -118,12 +118,12 @@
     }
   }
 
-  .#{$prefix}--footer-ext__legal__nav__links {
+  .#{$prefix}--footer-ext__legal-links {
     display: flex;
   }
 
-  .#{$prefix}--footer-ext__legal__nav__links__link {
-    & + .#{$prefix}--footer-ext__legal__nav__links__link {
+  .#{$prefix}--footer-ext__legal-link {
+    & + .#{$prefix}--footer-ext__legal-link {
       margin-left: $spacing-07;
     }
 

--- a/packages/styles/scss/components/footer/_footer_external.scss
+++ b/packages/styles/scss/components/footer/_footer_external.scss
@@ -17,7 +17,7 @@
     grid-template-columns: 2fr 3fr;
     padding-bottom: $spacing-05;
 
-    @include breakpoint-down(md) {
+    @media (max-width: 860px) {
       grid-template-columns: 1fr;
     }
   }
@@ -68,29 +68,40 @@
   }
 
   .#{$prefix}--footer-ext__nav-wrapper {
-    display: grid;
-    gap: $spacing-07;
-    grid-template-columns: repeat(2, 1fr);
+    display: flex;
 
     @include breakpoint-down(md) {
-      grid-template-columns: 1fr;
+      flex-direction: column;
     }
   }
 
-  .#{$prefix}--footer-ext__nav-title {
+  /* Block LinksColumn */
+  // Give each column equal width
+  .#{$prefix}--links-column {
+    flex: 1;
+
+    // Apply space between any column
+    & + .#{$prefix}--links-column {
+      margin-left: $spacing-07;
+
+      @include breakpoint-down(md) {
+        margin-left: 0;
+        margin-top: $spacing-07;
+      }
+    }
+  }
+
+  .#{$prefix}--links-column__title {
     color: #36b5c5; // TODO: Use the token
     font-weight: 700; // TODO: Use the token
+    margin-bottom: $spacing-05;
     text-transform: uppercase;
   }
 
-  .#{$prefix}--footer-ext__nav-list {
-    margin-top: $spacing-05;
-  }
-
-  .#{$prefix}--footer-ext__nav-link {
+  .#{$prefix}--links-column-link {
     font-weight: 600; // TODO: Use the token
 
-    & + .#{$prefix}--footer-ext__nav-link {
+    & + .#{$prefix}--links-column-link {
       margin-top: $spacing-04;
     }
 
@@ -102,6 +113,7 @@
       }
     }
   }
+  /* End block LinksColumn */
 
   .#{$prefix}--footer-ext__legal {
     @include type-style('body-short-01');

--- a/packages/styles/scss/components/footer/_footer_external.scss
+++ b/packages/styles/scss/components/footer/_footer_external.scss
@@ -6,7 +6,7 @@
 
 @mixin footer_external {
   .#{$prefix}--footer-ext {
-    background-color: #1a4262; // TODO: Use the token $background-brand-dark
+    background-color: #1a4262; // TODO: Use the token $brand-dark
     color: $text-on-color;
     padding: $spacing-07 $spacing-03;
   }
@@ -28,8 +28,9 @@
   }
 
   .#{$prefix}--footer-ext__product-name {
-    @include type-style('productive-heading-03');
-    font-weight: 700; // TODO: Use the token
+    @include type-style('expressive-heading-03');
+
+    font-weight: 700;
     margin-left: $spacing-07;
     text-transform: uppercase;
   }
@@ -89,15 +90,19 @@
     }
   }
 
+  // [1] TODO: Create a token for the all caps title.
+  //     It's used for links titles on the Footer and for bookmarks on the Landing page.
   .#{$prefix}--links-column__title {
     color: #36b5c5; // TODO: Use the token
-    font-weight: 700; // TODO: Use the token
+    font-size: 1rem; // [1]
+    font-weight: 700; // [1]
+    letter-spacing: 0.05rem; // [1]
     margin-bottom: $spacing-05;
-    text-transform: uppercase;
+    text-transform: uppercase; // [1]
   }
 
   .#{$prefix}--links-column-link {
-    font-weight: 600; // TODO: Use the token
+    font-weight: 600;
 
     & + .#{$prefix}--links-column-link {
       margin-top: $spacing-04;
@@ -128,14 +133,11 @@
   }
 
   .#{$prefix}--footer-ext__legal-links {
+    gap: $spacing-07;
     display: flex;
   }
 
   .#{$prefix}--footer-ext__legal-link {
-    & + .#{$prefix}--footer-ext__legal-link {
-      margin-left: $spacing-07;
-    }
-
     & > a {
       color: $text-on-color;
 

--- a/packages/styles/scss/components/footer/_footer_external.scss
+++ b/packages/styles/scss/components/footer/_footer_external.scss
@@ -47,15 +47,13 @@
   }
 
   .#{$prefix}--footer-ext__social-icons-list {
+    align-items: center;
     display: flex;
+    gap: $spacing-04;
     margin-top: $spacing-03;
   }
 
   .#{$prefix}--footer-ext__social-icon {
-    & + .#{$prefix}--footer-ext__social-icon {
-      margin-left: $spacing-03;
-    }
-
     & a {
       cursor: pointer;
     }

--- a/packages/styles/scss/components/footer/_footer_external.scss
+++ b/packages/styles/scss/components/footer/_footer_external.scss
@@ -29,7 +29,6 @@
 
   .#{$prefix}--footer-ext__product-name {
     @include type-style('productive-heading-03');
-
     font-weight: 700; // TODO: Use the token
     margin-left: $spacing-07;
     text-transform: uppercase;

--- a/packages/styles/scss/components/footer/_index.scss
+++ b/packages/styles/scss/components/footer/_index.scss
@@ -6,6 +6,9 @@
 //
 
 @forward 'footer';
+@forward 'footer_external';
 @use 'footer';
+@use 'footer_external';
 
 @include footer.footer;
+@include footer_external.footer_external;

--- a/packages/ui/src/components/Footer/Footer.js
+++ b/packages/ui/src/components/Footer/Footer.js
@@ -4,6 +4,7 @@ import classnames from 'classnames';
 import Link from '../Link';
 import Wrapper from '../Wrapper';
 import Icon from '../Icon';
+import {FooterExternal} from './FooterExternal';
 import {
   WfpLogoStandardBlackEn,
   WfpLogoVerticalEn,
@@ -32,17 +33,22 @@ const Footer = ({
   secondary,
   sdgLogo,
   pageWidth,
+  productName,
   ...other
 }) => {
   const classNames = classnames(
     `${prefix}--footer`,
-    { [`${prefix}--footer--external`]: external },
+    // { [`${prefix}--footer--external`]: external },
     className
   );
   const standardLogo = `${process.env.STORYBOOK_ASSETS}logos/standard/en/wfp-logo-standard-black-en.svg`;
 
-  const footer = (
-    <footer className={classNames}>
+  const footer = 
+    external ? (
+    <FooterExternal productName={productName} metaContent={metaContent} metaLinks={metaLinks}>{children}</FooterExternal> 
+    ) : 
+    (
+      <footer className={classNames}>
       <Wrapper pageWidth={pageWidth}>
         <div className={`${prefix}--footer__content`}>
           {/* <div className="wfp--footer__info-content"> */}
@@ -129,9 +135,12 @@ const Footer = ({
           </div>
         )}
       </Wrapper>
-    </footer>
-  );
+     </footer>
+    );
 
+   
+  
+  
   return footer;
 };
 
@@ -140,6 +149,10 @@ Footer.propTypes = {
    The content of the footer containing relevant links
  */
   children: PropTypes.node,
+  /**
+   `productName` prop is to be used in external footers.
+  */
+  productName: PropTypes.node,
   /**
    Additional className which will be added
  */
@@ -152,6 +165,11 @@ Footer.propTypes = {
    Meta content, usually the copyright notice
  */
   metaContent: PropTypes.node,
+
+  /** 
+   Meta links, usually are leagal links like privacy, terms of use.
+ */
+  metaLinks: PropTypes.node,
   /**
    Optional WFP logo for mobile devices, can be used if the Logo should be provided by the CDN
  */

--- a/packages/ui/src/components/Footer/Footer.stories.js
+++ b/packages/ui/src/components/Footer/Footer.stories.js
@@ -2,7 +2,8 @@ import React from 'react';
 
 import markdown from './README.mdx';
 
-import Footer from '.';
+import { Footer, FooterExternal } from '.';
+
 import Link from '../Link';
 
 export default {
@@ -63,32 +64,7 @@ Regular.args = {
   external: false,
 };
 
-export const External = (args) => (
-  <Footer
-    {...args}
-    secondary={
-      <div>
-        Via C. G. Viola 68 Parco dei Medici
-        <br />
-        00148 Rome, Italy
-      </div>
-    }>
-    <div>
-      The United Nations World Food Programme is the 2020 Nobel Peace Prize Laureate. 
-      We are the world's largest humanitarian organization, 
-      saving lives in emergencies and using food assistance to build a pathway to peace, 
-      stability and prosperity for people recovering from conflict, disasters
-      <br />
-      <Link href="http://www.wfp.org">Custom Links</Link>
-    </div>
-  </Footer>
-);
-
-External.args = {
-  metaContent: '2019 © World Food Programme',
-  metaLinks:<Link href="http://www.wfp.org">meta link</Link>,
-  external: true,
-};
+export const External = () => <FooterExternal />;
 
 External.story = {
   parameters: {

--- a/packages/ui/src/components/Footer/Footer.stories.js
+++ b/packages/ui/src/components/Footer/Footer.stories.js
@@ -2,13 +2,15 @@ import React from 'react';
 
 import markdown from './README.mdx';
 
-import { Footer, FooterExternal } from '.';
+import { Footer } from '.';
+import { FooterMetaLink } from './FooterExternal';
 
 import Link from '../Link';
 
 export default {
   title: 'Components/UI Elements/Footer',
   component: Footer,
+
   parameters: {
     componentSubtitle: 'Component',
     status: 'released',
@@ -20,7 +22,6 @@ export default {
 export const Regular = (args) => {
   return (
     <Footer {...args}>
-      {!args.external ? (
         <div className="wfp--footer__info">
           <div className="wfp--footer__info__item">
             <p className="wfp--footer__label">A label</p>
@@ -45,17 +46,6 @@ export const Regular = (args) => {
             </ul>
           </div>
         </div>
-      ) : (
-        <div>
-          The United Nations World Food Programme - saving lives in emergencies
-          and changing lives for millions through sustainable development. WFP
-          works in more than 80 countries around the world, feeding people
-          caught in conflict and disasters, and laying the foundations for a
-          better future.
-          <br />
-          <Link href="http://www.wfp.org">Custom Links</Link>
-        </div>
-      )}
     </Footer>
   );
 };
@@ -64,7 +54,70 @@ Regular.args = {
   external: false,
 };
 
-export const External = () => <FooterExternal />;
+export const External = (args) => 
+(
+<Footer {...args} 
+ metaLinks={
+  <>
+    <FooterMetaLink href="hh.com">First legal link</FooterMetaLink>
+    <FooterMetaLink href="hh.com">Second legal link</FooterMetaLink>
+  </>
+}
+>
+  <div className={`wfp--footer-ext__nav-column`}>
+    <p className={`wfp--footer-ext__nav-title`}>First title</p>
+    <nav>
+      <ul className={`wfp--footer-ext__nav-list`}>
+        <li className={`wfp--footer-ext__nav-link`}>
+          <Link>First link</Link>
+        </li>
+        <li className={`wfp--footer-ext__nav-link`}>
+          <Link>Second link</Link>
+        </li>
+        <li className={`wfp--footer-ext__nav-link`}>
+          <Link>Third link</Link>
+        </li>
+        <li className={`wfp--footer-ext__nav-link`}>
+          <Link>Fourth link</Link>
+        </li>
+        <li className={`wfp--footer-ext__nav-link`}>
+          <Link>Fifth link</Link>
+        </li>
+      </ul>
+    </nav>
+  </div>
+  <div className={`wfp--footer-ext__nav-column`}>
+    <p className={`wfp--footer-ext__nav-title`}>Second title</p>
+    <nav>
+      <ul className={`wfp--footer-ext__nav-list`}>
+        <li className={`wfp--footer-ext__nav-link`}>
+          <Link>First link</Link>
+        </li>
+        <li className={`wfp--footer-ext__nav-link`}>
+          <Link>Second link</Link>
+        </li>
+        <li className={`wfp--footer-ext__nav-link`}>
+          <Link>Third link</Link>
+        </li>
+        <li className={`wfp--footer-ext__nav-link`}>
+          <Link>Fourth link</Link>
+        </li>
+        <li className={`wfp--footer-ext__nav-link`}>
+          <Link>Fifth link</Link>
+        </li>
+      </ul>
+    </nav>
+  </div>
+</Footer>
+);
+
+
+
+External.args = {
+  external: true,
+  productName: <span>Service <br/> Marketplace</span>,
+  metaContent: 'Via C. G. Viola 68 Parco dei Medici, 00148 Rome, Italy'
+};
 
 External.story = {
   parameters: {

--- a/packages/ui/src/components/Footer/FooterExternal.js
+++ b/packages/ui/src/components/Footer/FooterExternal.js
@@ -1,0 +1,142 @@
+import React from 'react';
+
+import Icon from '../Icon';
+import Link from '../Link';
+import Wrapper from '../Wrapper';
+
+import { Home16 } from '@wfp/icons-react';
+import { iconHome } from '@wfp/icons';
+import { WfpLogoVerticalEn } from '@wfp/pictograms-react';
+
+import { settings } from '../../globals/js';
+
+const { prefix } = settings;
+
+const ExternalFooter = () => (
+  <footer className={`${prefix}--footer-ext`}>
+    <Wrapper pageWidth="lg">
+      <div className={`${prefix}--footer-ext__content`}>
+        <div className={`${prefix}--footer-ext__content__corporate`}>
+          <div className={`${prefix}--footer-ext__content__corporate__logo`}>
+            <WfpLogoVerticalEn alt="WFP" />
+            <div
+              className={`${prefix}--footer-ext__content__corporate__logo__service`}>
+              <span>
+                Product <br />
+                Name
+              </span>
+            </div>
+          </div>
+          <div className={`${prefix}--footer-ext__content__corporate__address`}>
+            Via C. G. Viola 68 Parco dei Medici, 00148 Rome, Italy
+          </div>
+          <div className={`${prefix}--footer-ext__content__corporate__social`}>
+            <p>Follow WFP on:</p>
+            <ul
+              className={`${prefix}--footer-ext__content__corporate__social__list`}>
+              <li
+                className={`${prefix}--footer-ext__content__corporate__social__list__icon`}>
+                <a>
+                  <Home16 icon={Home16} height={24} width={24} />
+                </a>
+              </li>
+              <li
+                className={`${prefix}--footer-ext__content__corporate__social__list__icon`}>
+                <a>
+                  <Home16 icon={Home16} height={24} width={24} />
+                </a>
+              </li>
+              <li
+                className={`${prefix}--footer-ext__content__corporate__social__list__icon`}>
+                <a>
+                  <Home16 icon={Home16} height={24} width={24} />
+                </a>
+              </li>
+              <li
+                className={`${prefix}--footer-ext__content__corporate__social__list__icon`}>
+                <a>
+                  <Home16 icon={Home16} height={24} width={24} />
+                </a>
+              </li>
+              <li
+                className={`${prefix}--footer-ext__content__corporate__social__list__icon`}>
+                <a>
+                  <Home16 icon={Home16} height={24} width={24} />
+                </a>
+              </li>
+            </ul>
+          </div>
+        </div>
+        <div className={`${prefix}--footer-ext__content__links`}>
+          <div className={`${prefix}--footer-ext__content__links__column`}>
+            <p
+              className={`${prefix}--footer-ext__content__links__column__title`}>
+              First title
+            </p>
+            <nav>
+              <ul
+                className={`${prefix}--footer-ext__content__links__column__nav-list`}>
+                <li>
+                  <Link>First link</Link>
+                </li>
+                <li>
+                  <Link>Second link</Link>
+                </li>
+                <li>
+                  <Link>Third link</Link>
+                </li>
+                <li>
+                  <Link>Fourth link</Link>
+                </li>
+                <li>
+                  <Link>Fifth link</Link>
+                </li>
+              </ul>
+            </nav>
+          </div>
+          <div className={`${prefix}--footer-ext__content__links__column`}>
+            <p
+              className={`${prefix}--footer-ext__content__links__column__title`}>
+              Second title
+            </p>
+            <nav>
+              <ul
+                className={`${prefix}--footer-ext__content__links__column__nav-list`}>
+                <li>
+                  <Link>First link</Link>
+                </li>
+                <li>
+                  <Link>Second link</Link>
+                </li>
+                <li>
+                  <Link>Third link</Link>
+                </li>
+                <li>
+                  <Link>Fourth link</Link>
+                </li>
+                <li>
+                  <Link>Fifth link</Link>
+                </li>
+              </ul>
+            </nav>
+          </div>
+        </div>
+      </div>
+      <div className={`${prefix}--footer-ext__legal`}>
+        <span>{new Date().getFullYear()} © World Food Programme</span>
+        <nav className={`${prefix}--footer-ext__legal__nav`}>
+          <ul className={`${prefix}--footer-ext__legal__nav__links`}>
+            <li className={`${prefix}--footer-ext__legal__nav__links__link`}>
+              <Link>First legal link</Link>
+            </li>
+            <li className={`${prefix}--footer-ext__legal__nav__links__link`}>
+              <Link>Second legal link</Link>
+            </li>
+          </ul>
+        </nav>
+      </div>
+    </Wrapper>
+  </footer>
+);
+
+export default ExternalFooter;

--- a/packages/ui/src/components/Footer/FooterExternal.js
+++ b/packages/ui/src/components/Footer/FooterExternal.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import Link from '../Link';
 import Wrapper from '../Wrapper';
 import classnames from 'classnames';
-import { Home16 } from '@wfp/icons-react';
 import { WfpLogoVerticalEn } from '@wfp/pictograms-react';
 
 import { settings } from '../../globals/js';
@@ -36,28 +35,51 @@ const FooterExternal = ({
               <p>Follow WFP on:</p>
               <ul className={`${prefix}--footer-ext__social-icons-list`}>
                 <li className={`${prefix}--footer-ext__social-icon`}>
-                  <a>
-                    <Home16 icon={Home16} height={24} width={24} />
+                  <a
+                    href="https://twitter.com/WFP"
+                    target="_blank"
+                    rel="noopener">
+                    <TwitterIcon />
                   </a>
                 </li>
                 <li className={`${prefix}--footer-ext__social-icon`}>
-                  <a>
-                    <Home16 icon={Home16} height={24} width={24} />
+                  <a
+                    href="https://www.facebook.com/WorldFoodProgramme"
+                    target="_blank"
+                    rel="noopener">
+                    <FacebookIcon />
                   </a>
                 </li>
                 <li className={`${prefix}--footer-ext__social-icon`}>
-                  <a>
-                    <Home16 icon={Home16} height={24} width={24} />
+                  <a
+                    href="https://www.instagram.com/Worldfoodprogramme/"
+                    target="_blank"
+                    rel="noopener">
+                    <InstagramIcon />
                   </a>
                 </li>
                 <li className={`${prefix}--footer-ext__social-icon`}>
-                  <a>
-                    <Home16 icon={Home16} height={24} width={24} />
+                  <a
+                    href="https://www.linkedin.com/company/world-food-programme"
+                    target="_blank"
+                    rel="noopener">
+                    <LinkedinIcon />
                   </a>
                 </li>
                 <li className={`${prefix}--footer-ext__social-icon`}>
-                  <a>
-                    <Home16 icon={Home16} height={24} width={24} />
+                  <a
+                    href="https://www.youtube.com/user/WORLDFOODPROGRAM"
+                    target="_blank"
+                    rel="noopener">
+                    <YoutubeIcon />
+                  </a>
+                </li>
+                <li className={`${prefix}--footer-ext__social-icon`}>
+                  <a
+                    href="https://www.tiktok.com/@worldfoodprogramme"
+                    target="_blank"
+                    rel="noopener">
+                    <TiktokIcon />
                   </a>
                 </li>
               </ul>
@@ -140,5 +162,132 @@ FooterMetaLink.propTypes = {
   href: PropTypes.string,
   children: PropTypes.node,
 };
+
+/**
+ * Twitter social icon
+ */
+const TwitterIcon = () => (
+  <svg xmlns="http://www.w3.org/2000/svg" width={24} height={24}>
+    <title>Twitter icon</title>
+    <defs>
+      <clipPath id="prefix__a">
+        <path d="M0 0h24v24H0z" />
+      </clipPath>
+    </defs>
+    <g clipPath="url(#prefix__a)">
+      <path
+        data-name="Social Icons \u2013 24px / Twitter"
+        d="M21 24H3a3 3 0 01-3-3V3a3 3 0 013-3h18a3 3 0 013 3v18a3 3 0 01-3 3zM4.507 16.722A8.754 8.754 0 009.216 18.1a8.386 8.386 0 006.5-2.854 9.057 9.057 0 002.255-5.9c0-.13 0-.264-.006-.4A6.222 6.222 0 0019.5 7.35a6.27 6.27 0 01-1.77.486 3.09 3.09 0 001.356-1.7 6.135 6.135 0 01-1.956.744 3.078 3.078 0 00-5.323 2.106 3.408 3.408 0 00.078.7 8.765 8.765 0 01-6.341-3.218 3.089 3.089 0 00.954 4.11 3.131 3.131 0 01-1.392-.384v.042a3.085 3.085 0 002.466 3.018 3.087 3.087 0 01-1.386.054 3.07 3.07 0 002.874 2.136 6.138 6.138 0 01-3.822 1.32 5.9 5.9 0 01-.731-.042z"
+        fill="#fff"
+      />
+    </g>
+  </svg>
+);
+
+/**
+ * Facebook social icon
+ */
+const FacebookIcon = () => (
+  <svg xmlns="http://www.w3.org/2000/svg" width={24} height={24}>
+    <title>Facebook icon</title>
+    <defs>
+      <clipPath id="prefix__a">
+        <path d="M0 0h24v24H0z" />
+      </clipPath>
+    </defs>
+    <g clipPath="url(#prefix__a)">
+      <path
+        data-name="Social Icons \u2013 24px / Facebook"
+        d="M22.676 0H1.324A1.324 1.324 0 000 1.324v21.352A1.324 1.324 0 001.324 24h11.5v-9.281H9.7v-3.633h3.124V8.412c0-3.1 1.9-4.788 4.659-4.788a26.565 26.565 0 012.789.141v3.24h-1.9c-1.506 0-1.8.712-1.8 1.763v2.313h3.6l-.472 3.633h-3.148V24h6.124A1.324 1.324 0 0024 22.676V1.324A1.324 1.324 0 0022.676 0z"
+        fill="#fff"
+      />
+    </g>
+  </svg>
+);
+
+/**
+ * Instagram social icon
+ */
+const InstagramIcon = () => (
+  <svg xmlns="http://www.w3.org/2000/svg" width={24} height={24}>
+    <title>Instagram icon</title>
+    <defs>
+      <clipPath id="prefix__a">
+        <path d="M0 0h24v24H0z" />
+      </clipPath>
+    </defs>
+    <g clipPath="url(#prefix__a)">
+      <path
+        data-name="Social Icons \u2013 24px / Instagram"
+        d="M7.053 23.928a8.866 8.866 0 01-2.913-.558 5.9 5.9 0 01-2.126-1.384A5.88 5.88 0 01.63 19.86a8.853 8.853 0 01-.558-2.912C.014 15.653 0 15.224 0 12s.014-3.653.072-4.947A8.853 8.853 0 01.63 4.14a5.88 5.88 0 011.384-2.126A5.88 5.88 0 014.14.63 8.853 8.853 0 017.053.072C8.347.014 8.775 0 12 0s3.653.014 4.948.072A8.853 8.853 0 0119.86.63a5.88 5.88 0 012.126 1.384A5.9 5.9 0 0123.37 4.14a8.866 8.866 0 01.557 2.913C23.986 8.331 24 8.757 24 12s-.014 3.669-.072 4.948a8.865 8.865 0 01-.557 2.912 6.138 6.138 0 01-3.51 3.51 8.865 8.865 0 01-2.912.557c-1.279.058-1.7.072-4.948.072s-3.67-.013-4.948-.071zm.1-21.7a6.67 6.67 0 00-2.228.413 3.733 3.733 0 00-1.38.9 3.733 3.733 0 00-.9 1.38 6.67 6.67 0 00-.413 2.228C2.174 8.4 2.162 8.78 2.162 12s.012 3.6.07 4.849a6.67 6.67 0 00.413 2.228 3.733 3.733 0 00.9 1.38 3.733 3.733 0 001.38.9 6.64 6.64 0 002.228.413c1.252.058 1.629.07 4.849.07s3.6-.012 4.849-.07a6.64 6.64 0 002.228-.413 3.975 3.975 0 002.278-2.278 6.64 6.64 0 00.413-2.228c.058-1.252.07-1.629.07-4.849s-.012-3.6-.07-4.849a6.64 6.64 0 00-.413-2.228 3.733 3.733 0 00-.9-1.38 3.733 3.733 0 00-1.38-.9 6.67 6.67 0 00-2.228-.413c-1.249-.058-1.629-.07-4.849-.07s-3.6.012-4.849.07zM5.838 12A6.162 6.162 0 1112 18.162 6.169 6.169 0 015.838 12zM8 12a4 4 0 104-4 4.005 4.005 0 00-4 4zm8.966-6.405a1.44 1.44 0 111.439 1.439 1.44 1.44 0 01-1.439-1.439z"
+        fill="#fff"
+      />
+    </g>
+  </svg>
+);
+
+/**
+ * LinkedIn social icon
+ */
+const LinkedinIcon = () => (
+  <svg xmlns="http://www.w3.org/2000/svg" width={24} height={24}>
+    <title>LinkedIn icon</title>
+    <defs>
+      <clipPath id="prefix__a">
+        <path d="M0 0h24v24H0z" />
+      </clipPath>
+    </defs>
+    <g clipPath="url(#prefix__a)">
+      <path
+        data-name="Social Icons \u2013 24px / LinkedIn"
+        d="M22.224 24H1.77A1.753 1.753 0 010 22.268V1.731A1.753 1.753 0 011.77 0h20.454A1.756 1.756 0 0124 1.731v20.537A1.756 1.756 0 0122.224 24zM9.353 9v11.451h3.555v-5.665c0-1.454.254-2.941 2.134-2.941 1.85 0 1.85 1.755 1.85 3.036v5.571h3.559V14.17a7.2 7.2 0 00-.784-3.886 3.764 3.764 0 00-3.487-1.571 3.763 3.763 0 00-3.368 1.849h-.049V9zm-5.8 0v11.451h3.565V9zm1.786-5.7A2.065 2.065 0 107.4 5.368 2.068 2.068 0 005.339 3.3z"
+        fill="#fff"
+      />
+    </g>
+  </svg>
+);
+
+/**
+ * YouTube social icon
+ */
+const YoutubeIcon = () => (
+  <svg
+    width={24}
+    height={17}
+    xmlns="http://www.w3.org/2000/svg"
+    xmlnsXlink="http://www.w3.org/1999/xlink">
+    <title>YouTube icon</title>
+    <defs>
+      <path id="prefix__a" d="M0 0h24v24H0z" />
+    </defs>
+    <g transform="translate(0 -4)" fill="none" fillRule="evenodd">
+      <g mask="url(#prefix__b)" fill="#FFF" fillRule="nonzero">
+        <path d="M23.5 6.64a3.015 3.015 0 00-2.123-2.14C19.505 4 12 4 12 4s-7.505 0-9.377.5A3.015 3.015 0 00.5 6.64a33.951 33.951 0 000 11.628A3.015 3.015 0 002.623 20.4c1.872.5 9.377.5 9.377.5s7.505 0 9.377-.5a3.015 3.015 0 002.123-2.131c.669-3.847.669-7.78 0-11.628V6.64zM9.545 16.023V8.886l6.273 3.569-6.273 3.568z" />
+      </g>
+    </g>
+  </svg>
+);
+
+/**
+ * TikTok social icon
+ */
+const TiktokIcon = () => (
+  <svg xmlns="http://www.w3.org/2000/svg" width={24} height={24}>
+    <title>TikTok icon</title>
+    <defs>
+      <clipPath id="prefix__a">
+        <path d="M0 0h24v24H0z" />
+      </clipPath>
+    </defs>
+    <g clipPath="url(#prefix__a)">
+      <path
+        d="M22.225 24H1.769A1.753 1.753 0 010 22.268V1.73A1.752 1.752 0 011.769-.001h20.456a1.756 1.756 0 011.776 1.731v20.538A1.756 1.756 0 0122.225 24zM10.211 9.429a5.454 5.454 0 00-5.449 5.448 5.454 5.454 0 005.449 5.448 5.424 5.424 0 003.708-1.462 5.434 5.434 0 001.722-3.57h.018V8.851a6.919 6.919 0 004.034 1.29h.069V7.183h-.069a4.027 4.027 0 01-4.022-4.023h-3.009v11.9a2.47 2.47 0 01-2.451 2.274 2.463 2.463 0 01-2.459-2.46 2.462 2.462 0 012.459-2.458 2.448 2.448 0 01.758.121V9.481a5.43 5.43 0 00-.759-.052z"
+        fill="#fff"
+        stroke="rgba(0,0,0,0)"
+        strokeMiterlimit={10}
+      />
+    </g>
+  </svg>
+);
 
 export { FooterExternal, LinksColumn, FooterMetaLink };

--- a/packages/ui/src/components/Footer/FooterExternal.js
+++ b/packages/ui/src/components/Footer/FooterExternal.js
@@ -1,8 +1,8 @@
 import React from 'react';
-
+import PropTypes from 'prop-types';
 import Link from '../Link';
 import Wrapper from '../Wrapper';
-
+import classnames from 'classnames';
 import { Home16 } from '@wfp/icons-react';
 import { WfpLogoVerticalEn } from '@wfp/pictograms-react';
 
@@ -10,116 +10,106 @@ import { settings } from '../../globals/js';
 
 const { prefix } = settings;
 
-const ExternalFooter = () => (
-  <footer className={`${prefix}--footer-ext`}>
-    <Wrapper pageWidth="lg">
-      <div className={`${prefix}--footer-ext__content`}>
-        <div className={`${prefix}--footer-ext__info`}>
-          <div className={`${prefix}--footer-ext__branding`}>
-            <WfpLogoVerticalEn alt="WFP" />
-            <div className={`${prefix}--footer-ext__product-name`}>
-              <span>
-                Product <br />
-                Name
-              </span>
+const FooterExternal = ({className, productName, children, metaContent, metaLinks}) => {
+  const externalClasses = classnames(
+    `${prefix}--footer-ext`,
+    className
+  );
+  return(
+    <footer className={externalClasses}>
+      <Wrapper pageWidth="lg">
+        <div className={`${prefix}--footer-ext__content`}>
+          <div className={`${prefix}--footer-ext__info`}>
+            <div className={`${prefix}--footer-ext__branding`}>
+              <WfpLogoVerticalEn alt="WFP" />
+              <div className={`${prefix}--footer-ext__product-name`}>
+                  {productName}
+              </div>
+            </div>
+            <div className={`${prefix}--footer-ext__address`}>
+              {metaContent}
+            </div>
+            <div className={`${prefix}--footer-ext__social-wrapper`}>
+              <p>Follow WFP on:</p>
+              <ul className={`${prefix}--footer-ext__social-icons-list`}>
+                <li className={`${prefix}--footer-ext__social-icon`}>
+                  <a>
+                    <Home16 icon={Home16} height={24} width={24} />
+                  </a>
+                </li>
+                <li className={`${prefix}--footer-ext__social-icon`}>
+                  <a>
+                    <Home16 icon={Home16} height={24} width={24} />
+                  </a>
+                </li>
+                <li className={`${prefix}--footer-ext__social-icon`}>
+                  <a>
+                    <Home16 icon={Home16} height={24} width={24} />
+                  </a>
+                </li>
+                <li className={`${prefix}--footer-ext__social-icon`}>
+                  <a>
+                    <Home16 icon={Home16} height={24} width={24} />
+                  </a>
+                </li>
+                <li className={`${prefix}--footer-ext__social-icon`}>
+                  <a>
+                    <Home16 icon={Home16} height={24} width={24} />
+                  </a>
+                </li>
+              </ul>
             </div>
           </div>
-          <div className={`${prefix}--footer-ext__address`}>
-            Via C. G. Viola 68 Parco dei Medici, 00148 Rome, Italy
+          <div className={`${prefix}--footer-ext__nav-wrapper`}>
+                {children}
           </div>
-          <div className={`${prefix}--footer-ext__social-wrapper`}>
-            <p>Follow WFP on:</p>
-            <ul className={`${prefix}--footer-ext__social-icons-list`}>
-              <li className={`${prefix}--footer-ext__social-icon`}>
-                <a>
-                  <Home16 icon={Home16} height={24} width={24} />
-                </a>
-              </li>
-              <li className={`${prefix}--footer-ext__social-icon`}>
-                <a>
-                  <Home16 icon={Home16} height={24} width={24} />
-                </a>
-              </li>
-              <li className={`${prefix}--footer-ext__social-icon`}>
-                <a>
-                  <Home16 icon={Home16} height={24} width={24} />
-                </a>
-              </li>
-              <li className={`${prefix}--footer-ext__social-icon`}>
-                <a>
-                  <Home16 icon={Home16} height={24} width={24} />
-                </a>
-              </li>
-              <li className={`${prefix}--footer-ext__social-icon`}>
-                <a>
-                  <Home16 icon={Home16} height={24} width={24} />
-                </a>
-              </li>
+              
+        </div>
+        <div className={`${prefix}--footer-ext__legal`}>
+          <span>{new Date().getFullYear()} © World Food Programme</span>
+          <nav className={`${prefix}--footer-ext__nav-legal`}>
+            <ul className={`${prefix}--footer-ext__legal-links`}>
+              {metaLinks}
             </ul>
-          </div>
+          </nav>
         </div>
-        <div className={`${prefix}--footer-ext__nav-wrapper`}>
-          <div className={`${prefix}--footer-ext__nav-column`}>
-            <p className={`${prefix}--footer-ext__nav-title`}>First title</p>
-            <nav>
-              <ul className={`${prefix}--footer-ext__nav-list`}>
-                <li className={`${prefix}--footer-ext__nav-link`}>
-                  <Link>First link</Link>
-                </li>
-                <li className={`${prefix}--footer-ext__nav-link`}>
-                  <Link>Second link</Link>
-                </li>
-                <li className={`${prefix}--footer-ext__nav-link`}>
-                  <Link>Third link</Link>
-                </li>
-                <li className={`${prefix}--footer-ext__nav-link`}>
-                  <Link>Fourth link</Link>
-                </li>
-                <li className={`${prefix}--footer-ext__nav-link`}>
-                  <Link>Fifth link</Link>
-                </li>
-              </ul>
-            </nav>
-          </div>
-          <div className={`${prefix}--footer-ext__nav-column`}>
-            <p className={`${prefix}--footer-ext__nav-title`}>Second title</p>
-            <nav>
-              <ul className={`${prefix}--footer-ext__nav-list`}>
-                <li className={`${prefix}--footer-ext__nav-link`}>
-                  <Link>First link</Link>
-                </li>
-                <li className={`${prefix}--footer-ext__nav-link`}>
-                  <Link>Second link</Link>
-                </li>
-                <li className={`${prefix}--footer-ext__nav-link`}>
-                  <Link>Third link</Link>
-                </li>
-                <li className={`${prefix}--footer-ext__nav-link`}>
-                  <Link>Fourth link</Link>
-                </li>
-                <li className={`${prefix}--footer-ext__nav-link`}>
-                  <Link>Fifth link</Link>
-                </li>
-              </ul>
-            </nav>
-          </div>
-        </div>
-      </div>
-      <div className={`${prefix}--footer-ext__legal`}>
-        <span>{new Date().getFullYear()} © World Food Programme</span>
-        <nav className={`${prefix}--footer-ext__nav-legal`}>
-          <ul className={`${prefix}--footer-ext__legal-links`}>
-            <li className={`${prefix}--footer-ext__legal-link`}>
-              <Link>First legal link</Link>
-            </li>
-            <li className={`${prefix}--footer-ext__legal-link`}>
-              <Link>Second legal link</Link>
-            </li>
-          </ul>
-        </nav>
-      </div>
-    </Wrapper>
-  </footer>
-);
+      </Wrapper>
+    </footer>
+  );
+}
 
-export default ExternalFooter;
+FooterExternal.propTypes = {
+  /**
+   * The CSS class name to be placed on the wrapping element.
+   */
+  className: PropTypes.string,
+  productName: PropTypes.node,
+  children: PropTypes.node,
+  metaContent: PropTypes.node,
+  metaLinks: PropTypes.node,
+};
+
+
+
+const FooterMetaLink = ({ className, href, children }) => {
+  const wrapperClasses = classnames(
+    `${prefix}--footer-ext__legal-link`,
+    className
+  );
+  return (
+      <li className={wrapperClasses}>
+        <Link href={href} >{children}</Link>
+      </li>
+    );
+};
+
+FooterMetaLink.propTypes = {
+  /**
+   * The CSS class name to be placed on the wrapping element.
+   */
+  className: PropTypes.string,
+  href: PropTypes.string,
+  children: PropTypes.node,
+};
+
+export {FooterExternal, FooterMetaLink};

--- a/packages/ui/src/components/Footer/FooterExternal.js
+++ b/packages/ui/src/components/Footer/FooterExternal.js
@@ -10,12 +10,15 @@ import { settings } from '../../globals/js';
 
 const { prefix } = settings;
 
-const FooterExternal = ({className, productName, children, metaContent, metaLinks}) => {
-  const externalClasses = classnames(
-    `${prefix}--footer-ext`,
-    className
-  );
-  return(
+const FooterExternal = ({
+  className,
+  productName,
+  children,
+  metaContent,
+  metaLinks,
+}) => {
+  const externalClasses = classnames(`${prefix}--footer-ext`, className);
+  return (
     <footer className={externalClasses}>
       <Wrapper pageWidth="lg">
         <div className={`${prefix}--footer-ext__content`}>
@@ -23,7 +26,7 @@ const FooterExternal = ({className, productName, children, metaContent, metaLink
             <div className={`${prefix}--footer-ext__branding`}>
               <WfpLogoVerticalEn alt="WFP" />
               <div className={`${prefix}--footer-ext__product-name`}>
-                  {productName}
+                {productName}
               </div>
             </div>
             <div className={`${prefix}--footer-ext__address`}>
@@ -61,9 +64,9 @@ const FooterExternal = ({className, productName, children, metaContent, metaLink
             </div>
           </div>
           <div className={`${prefix}--footer-ext__nav-wrapper`}>
-                {children}
+            <LinksColumn />
+            <LinksColumn />
           </div>
-              
         </div>
         <div className={`${prefix}--footer-ext__legal`}>
           <span>{new Date().getFullYear()} © World Food Programme</span>
@@ -76,7 +79,7 @@ const FooterExternal = ({className, productName, children, metaContent, metaLink
       </Wrapper>
     </footer>
   );
-}
+};
 
 FooterExternal.propTypes = {
   /**
@@ -89,7 +92,33 @@ FooterExternal.propTypes = {
   metaLinks: PropTypes.node,
 };
 
-
+const LinksColumn = () => {
+  return (
+    <div className={`${prefix}--links-column`}>
+      {/* Title is optional */}
+      <p className={`${prefix}--links-column__title`}>Title</p>
+      <nav>
+        <ul className={`${prefix}--links-column__nav-list`}>
+          <li className={`${prefix}--links-column-link`}>
+            <Link>First link</Link>
+          </li>
+          <li className={`${prefix}--links-column-link`}>
+            <Link>Second link</Link>
+          </li>
+          <li className={`${prefix}--links-column-link`}>
+            <Link>Third link</Link>
+          </li>
+          <li className={`${prefix}--links-column-link`}>
+            <Link>Fourth link</Link>
+          </li>
+          <li className={`${prefix}--links-column-link`}>
+            <Link>Fifth link</Link>
+          </li>
+        </ul>
+      </nav>
+    </div>
+  );
+};
 
 const FooterMetaLink = ({ className, href, children }) => {
   const wrapperClasses = classnames(
@@ -97,10 +126,10 @@ const FooterMetaLink = ({ className, href, children }) => {
     className
   );
   return (
-      <li className={wrapperClasses}>
-        <Link href={href} >{children}</Link>
-      </li>
-    );
+    <li className={wrapperClasses}>
+      <Link href={href}>{children}</Link>
+    </li>
+  );
 };
 
 FooterMetaLink.propTypes = {
@@ -112,4 +141,4 @@ FooterMetaLink.propTypes = {
   children: PropTypes.node,
 };
 
-export {FooterExternal, FooterMetaLink};
+export { FooterExternal, LinksColumn, FooterMetaLink };

--- a/packages/ui/src/components/Footer/FooterExternal.js
+++ b/packages/ui/src/components/Footer/FooterExternal.js
@@ -1,11 +1,9 @@
 import React from 'react';
 
-import Icon from '../Icon';
 import Link from '../Link';
 import Wrapper from '../Wrapper';
 
 import { Home16 } from '@wfp/icons-react';
-import { iconHome } from '@wfp/icons';
 import { WfpLogoVerticalEn } from '@wfp/pictograms-react';
 
 import { settings } from '../../globals/js';
@@ -16,50 +14,43 @@ const ExternalFooter = () => (
   <footer className={`${prefix}--footer-ext`}>
     <Wrapper pageWidth="lg">
       <div className={`${prefix}--footer-ext__content`}>
-        <div className={`${prefix}--footer-ext__content__corporate`}>
-          <div className={`${prefix}--footer-ext__content__corporate__logo`}>
+        <div className={`${prefix}--footer-ext__info`}>
+          <div className={`${prefix}--footer-ext__branding`}>
             <WfpLogoVerticalEn alt="WFP" />
-            <div
-              className={`${prefix}--footer-ext__content__corporate__logo__service`}>
+            <div className={`${prefix}--footer-ext__product-name`}>
               <span>
                 Product <br />
                 Name
               </span>
             </div>
           </div>
-          <div className={`${prefix}--footer-ext__content__corporate__address`}>
+          <div className={`${prefix}--footer-ext__address`}>
             Via C. G. Viola 68 Parco dei Medici, 00148 Rome, Italy
           </div>
-          <div className={`${prefix}--footer-ext__content__corporate__social`}>
+          <div className={`${prefix}--footer-ext__social-wrapper`}>
             <p>Follow WFP on:</p>
-            <ul
-              className={`${prefix}--footer-ext__content__corporate__social__list`}>
-              <li
-                className={`${prefix}--footer-ext__content__corporate__social__list__icon`}>
+            <ul className={`${prefix}--footer-ext__social-icons-list`}>
+              <li className={`${prefix}--footer-ext__social-icon`}>
                 <a>
                   <Home16 icon={Home16} height={24} width={24} />
                 </a>
               </li>
-              <li
-                className={`${prefix}--footer-ext__content__corporate__social__list__icon`}>
+              <li className={`${prefix}--footer-ext__social-icon`}>
                 <a>
                   <Home16 icon={Home16} height={24} width={24} />
                 </a>
               </li>
-              <li
-                className={`${prefix}--footer-ext__content__corporate__social__list__icon`}>
+              <li className={`${prefix}--footer-ext__social-icon`}>
                 <a>
                   <Home16 icon={Home16} height={24} width={24} />
                 </a>
               </li>
-              <li
-                className={`${prefix}--footer-ext__content__corporate__social__list__icon`}>
+              <li className={`${prefix}--footer-ext__social-icon`}>
                 <a>
                   <Home16 icon={Home16} height={24} width={24} />
                 </a>
               </li>
-              <li
-                className={`${prefix}--footer-ext__content__corporate__social__list__icon`}>
+              <li className={`${prefix}--footer-ext__social-icon`}>
                 <a>
                   <Home16 icon={Home16} height={24} width={24} />
                 </a>
@@ -67,54 +58,46 @@ const ExternalFooter = () => (
             </ul>
           </div>
         </div>
-        <div className={`${prefix}--footer-ext__content__links`}>
-          <div className={`${prefix}--footer-ext__content__links__column`}>
-            <p
-              className={`${prefix}--footer-ext__content__links__column__title`}>
-              First title
-            </p>
+        <div className={`${prefix}--footer-ext__nav-wrapper`}>
+          <div className={`${prefix}--footer-ext__nav-column`}>
+            <p className={`${prefix}--footer-ext__nav-title`}>First title</p>
             <nav>
-              <ul
-                className={`${prefix}--footer-ext__content__links__column__nav-list`}>
-                <li>
+              <ul className={`${prefix}--footer-ext__nav-list`}>
+                <li className={`${prefix}--footer-ext__nav-link`}>
                   <Link>First link</Link>
                 </li>
-                <li>
+                <li className={`${prefix}--footer-ext__nav-link`}>
                   <Link>Second link</Link>
                 </li>
-                <li>
+                <li className={`${prefix}--footer-ext__nav-link`}>
                   <Link>Third link</Link>
                 </li>
-                <li>
+                <li className={`${prefix}--footer-ext__nav-link`}>
                   <Link>Fourth link</Link>
                 </li>
-                <li>
+                <li className={`${prefix}--footer-ext__nav-link`}>
                   <Link>Fifth link</Link>
                 </li>
               </ul>
             </nav>
           </div>
-          <div className={`${prefix}--footer-ext__content__links__column`}>
-            <p
-              className={`${prefix}--footer-ext__content__links__column__title`}>
-              Second title
-            </p>
+          <div className={`${prefix}--footer-ext__nav-column`}>
+            <p className={`${prefix}--footer-ext__nav-title`}>Second title</p>
             <nav>
-              <ul
-                className={`${prefix}--footer-ext__content__links__column__nav-list`}>
-                <li>
+              <ul className={`${prefix}--footer-ext__nav-list`}>
+                <li className={`${prefix}--footer-ext__nav-link`}>
                   <Link>First link</Link>
                 </li>
-                <li>
+                <li className={`${prefix}--footer-ext__nav-link`}>
                   <Link>Second link</Link>
                 </li>
-                <li>
+                <li className={`${prefix}--footer-ext__nav-link`}>
                   <Link>Third link</Link>
                 </li>
-                <li>
+                <li className={`${prefix}--footer-ext__nav-link`}>
                   <Link>Fourth link</Link>
                 </li>
-                <li>
+                <li className={`${prefix}--footer-ext__nav-link`}>
                   <Link>Fifth link</Link>
                 </li>
               </ul>
@@ -124,12 +107,12 @@ const ExternalFooter = () => (
       </div>
       <div className={`${prefix}--footer-ext__legal`}>
         <span>{new Date().getFullYear()} © World Food Programme</span>
-        <nav className={`${prefix}--footer-ext__legal__nav`}>
-          <ul className={`${prefix}--footer-ext__legal__nav__links`}>
-            <li className={`${prefix}--footer-ext__legal__nav__links__link`}>
+        <nav className={`${prefix}--footer-ext__nav-legal`}>
+          <ul className={`${prefix}--footer-ext__legal-links`}>
+            <li className={`${prefix}--footer-ext__legal-link`}>
               <Link>First legal link</Link>
             </li>
-            <li className={`${prefix}--footer-ext__legal__nav__links__link`}>
+            <li className={`${prefix}--footer-ext__legal-link`}>
               <Link>Second legal link</Link>
             </li>
           </ul>

--- a/packages/ui/src/components/Footer/index.js
+++ b/packages/ui/src/components/Footer/index.js
@@ -1,2 +1,2 @@
-export default from './Footer';
-
+export Footer from './Footer';
+export FooterExternal from './FooterExternal';


### PR DESCRIPTION
Closes @wfp/ui#

Built the new version of the External Footer component from the SMP redesign.
The component's data have not been abstracted, it only includes mocked data.
Styles work as expected.

#### Changelog

**New**

* New External Footer component with mocked data
* New Sass stylesheet for the External Footer

**Changed**

* Removed any reference of the old external footer from the Story
* Imported the new External Footer on the Story
* Loaded the new stylesheet

**Removed**

* No files have been removed
