### PR TITLE
Build the UI of the new External Card component

### DIFF
--- a/packages/styles/scss/components/card/_card-external.scss
+++ b/packages/styles/scss/components/card/_card-external.scss
@@ -1,0 +1,135 @@
+@use '../tag/mixins' as *;
+@use '../../config' as *;
+@use '../../spacing' as *;
+@use '../../theme' as *;
+@use '../../type' as *;
+@use '../../breakpoint' as *;
+
+@mixin card-external {
+  @include reset;
+
+  .#{$prefix}--card-ext {
+    border-radius: 4px;
+    box-shadow: 0 1px 8px rgb(0 0 0 / 15%);
+    display: flex;
+    flex-direction: column;
+    width: 268px;
+  }
+
+  .#{$prefix}--card-ext__label {
+    @include type-style('caption-01');
+
+    padding: $spacing-02 $spacing-05;
+
+    &.#{$prefix}--card-ext__label--neutral {
+      background-color: $layer; // Provide its own token
+      color: $text-secondary;
+    }
+
+    &.#{$prefix}--card-ext__label--success {
+      background-color: #ccdbcd;
+      color: #3f600f;
+    }
+  }
+
+  .#{$prefix}--card-ext__media {
+    & .#{$prefix}--card-ext__image {
+      height: 130px;
+      margin: 0;
+      object-fit: cover;
+      width: 100%;
+    }
+  }
+
+  .#{$prefix}--card-ext__info-wrapper {
+    display: flex;
+    flex-direction: column;
+    flex-grow: 1;
+    margin: 0 $spacing-05;
+    padding-bottom: $spacing-05;
+
+    // Show the divider only if the card has actions
+    &.#{$prefix}--card-ext__info-wrapper--with-divider {
+      border-bottom: 1px solid $border-strong;
+    }
+  }
+
+  .#{$prefix}--card-ext__primary-title {
+    padding-top: $spacing-05;
+  }
+
+  .#{$prefix}--card-ext__subheading {
+    @include type-style('caption-01');
+
+    color: $text-secondary;
+    font-weight: 700;
+    margin-bottom: $spacing-02;
+    overflow: hidden;
+    text-transform: uppercase;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .#{$prefix}--card-ext__heading {
+    @include type-style('expressive-heading-03');
+
+    color: $text-primary;
+    font-weight: 700;
+    line-height: 1.25;
+  }
+
+  .#{$prefix}--card-ext__supportive-text {
+    @include type-style('body-short-01');
+
+    color: $text-secondary;
+    flex-grow: 1;
+    padding-top: $spacing-03;
+
+    &.#{$prefix}--card-ext__supportive-text--truncated {
+      & > p {
+        display: -webkit-box;
+        overflow: hidden;
+        -webkit-box-orient: vertical;
+      }
+    }
+  }
+
+  .#{$prefix}--card-ext__tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: $spacing-03;
+    padding-top: $spacing-05;
+
+    & .#{$prefix}--card-ext__tag {
+      @include tag-theme(
+        $layer,
+        $text-secondary
+      ); // Provide its own token in replacement of 'layer'
+
+      display: block;
+      min-height: 0;
+      overflow: hidden;
+      padding: $spacing-02 $spacing-03;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+  }
+
+  .#{$prefix}--card-ext__actions {
+    align-items: center;
+    display: flex;
+    gap: $spacing-03;
+    padding: $spacing-03;
+  }
+
+  .#{$prefix}--card-ext__action {
+    // Whether the last action is aligned to the right
+    &.#{$prefix}--card-ext__action--align-to-right {
+      margin-left: auto;
+    }
+
+    &.#{$prefix}--btn--icon-only {
+      padding: 0 0.35rem;
+    }
+  }
+}

--- a/packages/styles/scss/components/card/_card-external.scss
+++ b/packages/styles/scss/components/card/_card-external.scss
@@ -33,12 +33,25 @@
   }
 
   .#{$prefix}--card-ext__media {
+    overflow: hidden;
+
     & .#{$prefix}--card-ext__image {
       height: 130px;
       margin: 0;
       object-fit: cover;
       width: 100%;
     }
+  }
+
+  // If the card is interactive, set up the properties for the animation.
+  .#{$prefix}--card-ext--interactive .#{$prefix}--card-ext__image {
+    transition: transform 0.3s ease 0s;
+    will-change: transform;
+  }
+
+  // If the card is interactive, animate the image on hover event.
+  .#{$prefix}--card-ext--interactive:hover .#{$prefix}--card-ext__image {
+    transform: scale(1.15);
   }
 
   .#{$prefix}--card-ext__info-wrapper {

--- a/packages/styles/scss/components/card/_card-external.scss
+++ b/packages/styles/scss/components/card/_card-external.scss
@@ -10,7 +10,7 @@
 
   .#{$prefix}--card-ext {
     border-radius: 4px;
-    box-shadow: 0 1px 8px rgb(0 0 0 / 15%);
+    box-shadow: 0 1px 8px rgb(0 0 0 / 15%); // TODO: Create new token
     display: flex;
     flex-direction: column;
     width: 268px;
@@ -27,8 +27,8 @@
     }
 
     &.#{$prefix}--card-ext__label--success {
-      background-color: #ccdbcd;
-      color: #3f600f;
+      background-color: #ccdbcd; // TODO: Create new token
+      color: #3f600f; // TODO: Use $text-success token
     }
   }
 

--- a/packages/styles/scss/components/card/_index.scss
+++ b/packages/styles/scss/components/card/_index.scss
@@ -6,6 +6,9 @@
 //
 
 @forward 'card';
+@forward 'card-external';
 @use 'card';
+@use 'card-external';
 
 @include card.card;
+@include card-external.card-external;

--- a/packages/ui/src/components/Card/Card.stories.js
+++ b/packages/ui/src/components/Card/Card.stories.js
@@ -2,7 +2,10 @@ import React from 'react';
 
 import markdown from './README.mdx';
 import cardTwig from './Card.twig';
+import Button from '../Button';
 import { Card, CardExternal } from '.';
+
+import { StarSolidGlyph } from '@wfp/icons-react';
 
 export default {
   title: 'Components/Content Related/Card',
@@ -51,7 +54,41 @@ Overlay.args = {
   cardHeight: '400px',
 };
 
-export const External = () => <CardExternal truncated />;
+export const External = (args) => (
+<CardExternal truncated {...args}>
+  <div className={`wfp--card-ext__actions`}>
+    <Button
+      className={`wfp--card-ext__action`}
+      kind="ghost"
+      small
+      style={{ textTransform: 'uppercase' }}>
+      Action 1
+    </Button>
+    <Button className={`wfp--card-ext__action`} kind="ghost" small>
+      Action 2
+    </Button>
+    {/* Last action can be aligned to the right with a dedicated modifier handled with a boolean prop (alignToRight) */}
+    {/* TODO: Provide the Star icon (outline version) from the kit */}
+    <Button
+      className={`wfp--card-ext__action wfp--card-ext__action--align-to-right`}
+      kind="ghost"
+      small
+      icon={StarSolidGlyph}
+      iconDescription="FavoriteOutline16"
+    />
+  </div>
+</CardExternal>
+);
+
+
+External.args ={
+  label:'Label',
+  heading: 'Heading',
+  subHeading: 'subheading',
+  caption:'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus vitae congue magna. Mauris vitae velit lacinia, porttitor tellus sit amet, hendrerit ipsum. Vivamus sagittis leo ut erat eleifend, sed',
+  tag:'tag',
+  labelStatus: true
+}
 
 External.story = {
   parameters: {

--- a/packages/ui/src/components/Card/Card.stories.js
+++ b/packages/ui/src/components/Card/Card.stories.js
@@ -2,7 +2,7 @@ import React from 'react';
 
 import markdown from './README.mdx';
 import cardTwig from './Card.twig';
-import Card from '.';
+import { Card, CardExternal } from '.';
 
 export default {
   title: 'Components/Content Related/Card',
@@ -11,8 +11,8 @@ export default {
     componentSubtitle: 'Component',
     status: 'released',
     mdx: markdown,
-    twig: cardTwig
-  }
+    twig: cardTwig,
+  },
 };
 
 export const SimpleCard = (args) => <Card {...args} />;
@@ -23,8 +23,8 @@ SimpleCard.args = {
   title: 'The Climate Adaption Mangement and Innovation Initiative',
   kind: 'simple-card',
   metadata: 'Publication',
-  url:'https://www.wfp.org',
-  isExternal:true,
+  url: 'https://www.wfp.org',
+  isExternal: true,
 };
 
 export const SimpleCardWithImage = (args) => <Card {...args} />;
@@ -37,7 +37,6 @@ SimpleCardWithImage.args = {
   metadata: 'Publication',
   image: 'http://www1.wfp.org/sites/default/files/images/yemen-hero-min.jpg',
 };
-
 
 export const Overlay = (args) => <Card {...args} />;
 
@@ -52,3 +51,12 @@ Overlay.args = {
   cardHeight: '400px',
 };
 
+export const External = () => <CardExternal truncated />;
+
+External.story = {
+  parameters: {
+    docs: {
+      storyDescription: 'Add a description',
+    },
+  },
+};

--- a/packages/ui/src/components/Card/Card.stories.js
+++ b/packages/ui/src/components/Card/Card.stories.js
@@ -10,6 +10,7 @@ import { StarSolidGlyph } from '@wfp/icons-react';
 export default {
   title: 'Components/Content Related/Card',
   component: Card,
+  subcomponents: {CardExternal},
   parameters: {
     componentSubtitle: 'Component',
     status: 'released',

--- a/packages/ui/src/components/Card/CardExternal.js
+++ b/packages/ui/src/components/Card/CardExternal.js
@@ -1,6 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
-
-import { StarSolid16 } from '@wfp/icons-react';
+import PropTypes from 'prop-types';
 
 import Button from '../Button';
 import Tag from '../Tag';
@@ -9,7 +8,7 @@ import { settings } from '../../globals/js';
 
 const { prefix } = settings;
 
-const CardExternal = (props) => {
+const CardExternal = ({ label , labelStatus, heading , subHeading , caption , tag, children, ...other}) => {
   const myRef = useRef();
   const supportiveTextFontSize = 14;
   const supportiveTextLineHeight = 1.5;
@@ -18,6 +17,9 @@ const CardExternal = (props) => {
   const [supportiveTextHeight, setsupportiveTextHeight] = useState(
     supportiveTextFontSize * supportiveTextLineHeight * 3
   );
+
+  // statusStyle apply different style(color, backgroundColor) based on its active state 
+  const statusStyle = labelStatus ? `success`: `neutral`;
 
   /**
    * Get the height of the supportive text element.
@@ -57,8 +59,8 @@ const CardExternal = (props) => {
        * It can be either 'neutral' (default) or 'success'
        */}
       <div
-        className={`${prefix}--card-ext__label ${prefix}--card-ext__label--success`}>
-        Label
+        className={`${prefix}--card-ext__label ${prefix}--card-ext__label--${statusStyle}`}>
+        {label}
       </div>
       <figure className={`${prefix}--card-ext__media`}>
         <img
@@ -72,13 +74,13 @@ const CardExternal = (props) => {
         className={`${prefix}--card-ext__info-wrapper ${prefix}--card-ext__info-wrapper--with-divider`}>
         <div className={`${prefix}--card-ext__primary-title`}>
           {/* Subheading is optional */}
-          <p className={`${prefix}--card-ext__subheading`}>Subheading</p>
-          <p className={`${prefix}--card-ext__heading`}>Heading</p>
+          {subHeading && ( <p className={`${prefix}--card-ext__subheading`}>{subHeading}</p>)}
+          {heading && (<p className={`${prefix}--card-ext__heading`}>{heading}</p>)} 
         </div>
         {/* Supportive text is optional */}
         <div
           className={
-            props.truncated
+            other.truncated
               ? `${prefix}--card-ext__supportive-text ${prefix}--card-ext__supportive-text--truncated`
               : `${prefix}--card-ext__supportive-text`
           }
@@ -91,48 +93,40 @@ const CardExternal = (props) => {
                   supportiveTextFontSize
               ),
             }}>
-            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus
-            vitae congue magna. Mauris vitae velit lacinia, porttitor tellus sit
-            amet, hendrerit ipsum. Vivamus sagittis leo ut erat eleifend, sed
-            bibendum metus porttitor. Nam ac consectetur dui. Aliquam
-            vestibulum, justo ac condimentum dignissim, odio sapien iaculis
-            risus, ac rhoncus dolor metus a nulla. Suspendisse potenti. Donec
-            lectus ante, mattis a tellus in, semper rhoncus metus. Ut pulvinar
-            et nisi nec vulputate. Morbi in ante finibus tortor vehicula
-            convallis congue vel justo.
+            {caption}
           </p>
         </div>
         {/* Tags are optional */}
+        {tag && (
         <div className={`${prefix}--card-ext__tags`}>
           <Tag className={`${prefix}--card-ext__tag`} type="custom">
-            Tag
+            {tag}
           </Tag>
-        </div>
+        </div>)
+        }
+        
       </div>
       {/* Better to allow only small buttons for alignment reasons */}
-      <div className={`${prefix}--card-ext__actions`}>
-        <Button
-          className={`${prefix}--card-ext__action`}
-          kind="ghost"
-          small
-          style={{ textTransform: 'uppercase' }}>
-          Action 1
-        </Button>
-        <Button className={`${prefix}--card-ext__action`} kind="ghost" small>
-          Action 2
-        </Button>
-        {/* Last action can be aligned to the right with a dedicated modifier handled with a boolean prop (alignToRight) */}
-        {/* TODO: Provide the Star icon (outline version) from the kit */}
-        <Button
-          className={`${prefix}--card-ext__action ${prefix}--card-ext__action--align-to-right`}
-          kind="ghost"
-          small
-          icon={StarSolid16}
-          iconDescription="FavoriteOutline16"
-        />
-      </div>
+      {children}
     </div>
   );
 };
+
+CardExternal.propTypes = {
+  /**
+   label description for card if any
+  */
+  label: PropTypes.string, 
+
+  /**
+   labelStatus is either true or false, it applies  for card if any
+  */
+  labelStatus: PropTypes.bool,
+  heading: PropTypes.string, 
+  subHeading: PropTypes.string, 
+  caption: PropTypes.string, 
+  tag: PropTypes.string, 
+  children: PropTypes.node
+}
 
 export default CardExternal;

--- a/packages/ui/src/components/Card/CardExternal.js
+++ b/packages/ui/src/components/Card/CardExternal.js
@@ -1,0 +1,132 @@
+import React, { useEffect, useRef, useState } from 'react';
+
+import { StarSolid16 } from '@wfp/icons-react';
+
+import Button from '../Button';
+import Tag from '../Tag';
+
+import { settings } from '../../globals/js';
+
+const { prefix } = settings;
+
+const CardExternal = (props) => {
+  const myRef = useRef();
+  const supportiveTextFontSize = 14;
+  const supportiveTextLineHeight = 1.5;
+
+  // Set a maximum of 3 lines of supportive text by default
+  const [supportiveTextHeight, setsupportiveTextHeight] = useState(
+    supportiveTextFontSize * supportiveTextLineHeight * 3
+  );
+
+  /**
+   * Get the height of the supportive text element.
+   * This is useful to calculate a dynamic maximum amount of line text with final
+   * ellipsis for the "supportive text" element, depending of the available
+   * height.
+   *
+   * Cards' title has no limits in terms of line text, whereas we can decide to
+   * truncate the supportive text at 3 number of lines. The multiline truncation
+   * can be obtained by using the "line clamp" CSS property that truncates text
+   * at a specific number of lines.
+   * The problem is, if we place three cards on a Flexbox/Grid parent, these
+   * cards will have the same height, depending on the highest of the three.
+   * This means that if one card has a multiline title, the other two will grow
+   * in height, showing a significant white space. To fill the latter cards'
+   * white space we need to increase the number of their "supportive text" lines.
+   * To do this we need to divide the "supportive text" element's height by its
+   * font-size and line-height in order to get exact amount of line text that are
+   * needed to fill the extra white space.
+   *
+   */
+  useEffect(() => {
+    setsupportiveTextHeight(myRef.current.offsetHeight);
+  }, [myRef]);
+
+  return (
+    /* Also expose a custom classname prop */
+    <div className={`${prefix}--card-ext`}>
+      {/*
+       * Label is optional.
+       * It can be either 'neutral' (default) or 'success'
+       */}
+      <div
+        className={`${prefix}--card-ext__label ${prefix}--card-ext__label--success`}>
+        Label
+      </div>
+      <figure className={`${prefix}--card-ext__media`}>
+        <img
+          className={`${prefix}--card-ext__image`}
+          src="http://www1.wfp.org/sites/default/files/images/yemen-hero-min.jpg"
+          alt="Card picture"
+        />
+      </figure>
+      {/* If card has actions, show a divider by adding a dedicated modifier handled with a boolean prop */}
+      <div
+        className={`${prefix}--card-ext__info-wrapper ${prefix}--card-ext__info-wrapper--with-divider`}>
+        <div className={`${prefix}--card-ext__primary-title`}>
+          {/* Subheading is optional */}
+          <p className={`${prefix}--card-ext__subheading`}>Subheading</p>
+          <p className={`${prefix}--card-ext__heading`}>Heading</p>
+        </div>
+        {/* Supportive text is optional */}
+        <div
+          className={
+            props.truncated
+              ? `${prefix}--card-ext__supportive-text ${prefix}--card-ext__supportive-text--truncated`
+              : `${prefix}--card-ext__supportive-text`
+          }
+          ref={myRef}>
+          <p
+            style={{
+              WebkitLineClamp: Math.floor(
+                supportiveTextHeight /
+                  supportiveTextLineHeight /
+                  supportiveTextFontSize
+              ),
+            }}>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus
+            vitae congue magna. Mauris vitae velit lacinia, porttitor tellus sit
+            amet, hendrerit ipsum. Vivamus sagittis leo ut erat eleifend, sed
+            bibendum metus porttitor. Nam ac consectetur dui. Aliquam
+            vestibulum, justo ac condimentum dignissim, odio sapien iaculis
+            risus, ac rhoncus dolor metus a nulla. Suspendisse potenti. Donec
+            lectus ante, mattis a tellus in, semper rhoncus metus. Ut pulvinar
+            et nisi nec vulputate. Morbi in ante finibus tortor vehicula
+            convallis congue vel justo.
+          </p>
+        </div>
+        {/* Tags are optional */}
+        <div className={`${prefix}--card-ext__tags`}>
+          <Tag className={`${prefix}--card-ext__tag`} type="custom">
+            Tag
+          </Tag>
+        </div>
+      </div>
+      {/* Better to allow only small buttons for alignment reasons */}
+      <div className={`${prefix}--card-ext__actions`}>
+        <Button
+          className={`${prefix}--card-ext__action`}
+          kind="ghost"
+          small
+          style={{ textTransform: 'uppercase' }}>
+          Action 1
+        </Button>
+        <Button className={`${prefix}--card-ext__action`} kind="ghost" small>
+          Action 2
+        </Button>
+        {/* Last action can be aligned to the right with a dedicated modifier handled with a boolean prop (alignToRight) */}
+        {/* TODO: Provide the Star icon (outline version) from the kit */}
+        <Button
+          className={`${prefix}--card-ext__action ${prefix}--card-ext__action--align-to-right`}
+          kind="ghost"
+          small
+          icon={StarSolid16}
+          iconDescription="FavoriteOutline16"
+        />
+      </div>
+    </div>
+  );
+};
+
+export default CardExternal;

--- a/packages/ui/src/components/Card/CardExternal.js
+++ b/packages/ui/src/components/Card/CardExternal.js
@@ -45,7 +45,13 @@ const CardExternal = (props) => {
 
   return (
     /* Also expose a custom classname prop */
-    <div className={`${prefix}--card-ext`}>
+    /**
+     * A prop will establish if the card is either informative (default) or
+     * interactive.
+     * If interactive, a modifier will be added and an animation will be shown
+     * on hover event ("${prefix}--card-ext--interactive").
+     */
+    <div className={`${prefix}--card-ext ${prefix}--card-ext--interactive`}>
       {/*
        * Label is optional.
        * It can be either 'neutral' (default) or 'success'

--- a/packages/ui/src/components/Card/index.js
+++ b/packages/ui/src/components/Card/index.js
@@ -1,1 +1,2 @@
-export default from './Card';
+export Card from './Card';
+export CardExternal from './CardExternal';


### PR DESCRIPTION
Closes @wfp/ui#

Built the new version of the External Card component from the SMP redesign.
The component's data have not been abstracted, it only includes mocked data.
Styles work as expected.

#### Changelog

**New**

* New External Card component with mocked data
* New Sass stylesheet for the External Card

**Changed**

* Imported the new External Card on the Story
* Loaded the new stylesheet

**Removed**

No files have been removed
