### PR TITLE
Build the UI of the new External Hero component

### DIFF
--- a/packages/styles/scss/components/hero/_hero-external.scss
+++ b/packages/styles/scss/components/hero/_hero-external.scss
@@ -1,0 +1,83 @@
+@use '../tag/mixins' as *;
+@use '../../config' as *;
+@use '../../spacing' as *;
+@use '../../theme' as *;
+@use '../../type' as *;
+@use '../../breakpoint' as *;
+
+@mixin hero-external {
+  @include reset;
+
+  .#{$prefix}--hero-ext {
+    background-size: cover;
+    padding: $spacing-12 $spacing-07;
+
+    @include breakpoint-down(lg) {
+      padding: $spacing-10 $spacing-07;
+    }
+
+    @include breakpoint-down(md) {
+      padding: $spacing-09 $spacing-03;
+    }
+  }
+
+  .#{$prefix}--hero-ext__heading {
+    color: $text-on-color;
+    font-size: 48px;
+    font-weight: 800;
+    line-height: 1.15;
+    text-align: center;
+    text-transform: uppercase;
+
+    @include breakpoint-down(lg) {
+      font-size: 36px;
+
+      & > br {
+        display: none;
+      }
+    }
+
+    @include breakpoint-down(md) {
+      font-size: 30px;
+      text-align: left;
+    }
+  }
+
+  .#{$prefix}--hero-ext__body-copy {
+    color: $text-on-color;
+    margin-top: $spacing-05;
+    text-align: center;
+
+    @include breakpoint-down(md) {
+      text-align: left;
+    }
+
+    & > b,
+    strong {
+      font-weight: 700;
+    }
+
+    & > a {
+      color: $text-on-color;
+      cursor: pointer;
+      text-decoration: underline;
+    }
+  }
+
+  .#{$prefix}--hero-ext__actions {
+    align-items: center;
+    display: flex;
+    gap: $spacing-07;
+    justify-content: center;
+    margin-top: $spacing-07;
+
+    @include breakpoint-down(lg) {
+      gap: $spacing-06;
+    }
+
+    @include breakpoint-down(md) {
+      gap: $spacing-05;
+      justify-content: flex-start;
+    }
+  }
+}

--- a/packages/styles/scss/components/hero/_hero-external.scss
+++ b/packages/styles/scss/components/hero/_hero-external.scss
@@ -21,16 +21,17 @@
     }
   }
 
+  // [1] TODO: Create new type-style token for the Hero heading
   .#{$prefix}--hero-ext__heading {
     color: $text-on-color;
-    font-size: 48px;
-    font-weight: 800;
-    line-height: 1.15;
+    font-size: 48px; // [1]
+    font-weight: 800; // [1]
+    line-height: 1.15; // [1]
     text-align: center;
-    text-transform: uppercase;
+    text-transform: uppercase; // [1]
 
     @include breakpoint-down(lg) {
-      font-size: 36px;
+      font-size: 36px; // [1]
 
       & > br {
         display: none;
@@ -38,7 +39,7 @@
     }
 
     @include breakpoint-down(md) {
-      font-size: 30px;
+      font-size: 30px; // [1]
       text-align: left;
     }
   }

--- a/packages/styles/scss/components/hero/_index.scss
+++ b/packages/styles/scss/components/hero/_index.scss
@@ -6,6 +6,9 @@
 //
 
 @forward 'hero';
+@forward 'hero-external';
 @use 'hero';
+@use 'hero-external';
 
 @include hero.hero;
+@include hero-external.hero-external;

--- a/packages/ui/src/components/Hero/Hero.stories.js
+++ b/packages/ui/src/components/Hero/Hero.stories.js
@@ -2,7 +2,7 @@ import React from 'react';
 
 import markdown from './README.mdx';
 
-import Hero from '.';
+import { Hero, HeroExternal } from '.';
 import Button from '../Button';
 import { WfpHumEmergencyResponsePos } from '@wfp/pictograms-react';
 import heroTwig from './Hero.twig';
@@ -57,7 +57,6 @@ HeroKinds.story = {
     },
   },
 };
-
 
 export const Landscape = (args) => <Hero {...args} />;
 
@@ -231,3 +230,28 @@ Emergencies.story = {
   },
 };
 */
+
+export const External = () => (
+  <HeroExternal
+    heading={[
+      'A headline that can be used ',
+      <br />,
+      'for the value proposition',
+    ]}
+    body={[
+      'A description that can contain a ',
+      <a>link</a>,
+      ' and ',
+      <strong>a bold text</strong>,
+      ' to highlight important content. We have room for one or more sentences. Like this.',
+    ]}
+  />
+);
+
+External.story = {
+  parameters: {
+    docs: {
+      storyDescription: 'Add a description',
+    },
+  },
+};

--- a/packages/ui/src/components/Hero/Hero.stories.js
+++ b/packages/ui/src/components/Hero/Hero.stories.js
@@ -231,22 +231,24 @@ Emergencies.story = {
 };
 */
 
-export const External = () => (
-  <HeroExternal
-    heading={[
-      'A headline that can be used ',
-      <br />,
-      'for the value proposition',
-    ]}
-    body={[
-      'A description that can contain a ',
-      <a>link</a>,
-      ' and ',
-      <strong>a bold text</strong>,
-      ' to highlight important content. We have room for one or more sentences. Like this.',
-    ]}
-  />
+export const External = (args) => (
+  <HeroExternal {...args}>
+    <div className={`wfp--hero-ext__actions`}>
+      <Button allCaps large kind="accent">
+        Accent action
+      </Button>
+      <Button allCaps large kind="inverse">
+        Secondary action
+      </Button>
+    </div>
+  </HeroExternal>
 );
+
+External.args = {
+  title: (<>A headline that can be used  <br /> for the value proposition</>),
+  subTitle: (<>A description that can contain a <a>link</a> and <strong>a bold text</strong> to highlight important content. We have room for one or more sentences. Like this.</>),
+  image:'http://www1.wfp.org/sites/default/files/images/yemen-hero-min.jpg'
+}
 
 External.story = {
   parameters: {

--- a/packages/ui/src/components/Hero/HeroExternal.js
+++ b/packages/ui/src/components/Hero/HeroExternal.js
@@ -12,6 +12,7 @@ const HeroExternal = (props) => {
     // TODO: Provide a prop [string] to set the backgrond position (optional).
     <div
       className={`${prefix}--hero-ext`}
+      // TODO: do we need a token for the linear gradient?
       style={{
         backgroundImage: `linear-gradient(rgba(26, 66, 98, 0.8), rgba(26, 66, 98, 0.8)), url(http://www1.wfp.org/sites/default/files/images/yemen-hero-min.jpg)`,
         backgroundPosition: 'center right',

--- a/packages/ui/src/components/Hero/HeroExternal.js
+++ b/packages/ui/src/components/Hero/HeroExternal.js
@@ -1,0 +1,37 @@
+import React from 'react';
+
+import Button from '../Button';
+import Wrapper from '../Wrapper';
+
+import { settings } from '../../globals/js';
+const { prefix } = settings;
+
+const HeroExternal = (props) => {
+  return (
+    // TODO: Provide a prop to set the backgrond image (linear-gradient should be not editable)
+    // TODO: Provide a prop [string] to set the backgrond position (optional).
+    <div
+      className={`${prefix}--hero-ext`}
+      style={{
+        backgroundImage: `linear-gradient(rgba(26, 66, 98, 0.8), rgba(26, 66, 98, 0.8)), url(http://www1.wfp.org/sites/default/files/images/yemen-hero-min.jpg)`,
+        backgroundPosition: 'center right',
+      }}>
+      <Wrapper pageWidth="md">
+        <div className={`${prefix}--hero-ext__content`}>
+          <h1 className={`${prefix}--hero-ext__heading`}>{props.heading}</h1>
+          <p className={`${prefix}--hero-ext__body-copy`}>{props.body}</p>
+        </div>
+        <div className={`${prefix}--hero-ext__actions`}>
+          <Button allCaps large kind="accent">
+            Accent action
+          </Button>
+          <Button allCaps large kind="inverse">
+            Secondary action
+          </Button>
+        </div>
+      </Wrapper>
+    </div>
+  );
+};
+
+export default HeroExternal;

--- a/packages/ui/src/components/Hero/HeroExternal.js
+++ b/packages/ui/src/components/Hero/HeroExternal.js
@@ -1,12 +1,12 @@
 import React from 'react';
-
+import PropTypes from 'prop-types';
 import Button from '../Button';
 import Wrapper from '../Wrapper';
 
 import { settings } from '../../globals/js';
 const { prefix } = settings;
 
-const HeroExternal = (props) => {
+const HeroExternal = ({title, subTitle, image, children}) => {
   return (
     // TODO: Provide a prop to set the backgrond image (linear-gradient should be not editable)
     // TODO: Provide a prop [string] to set the backgrond position (optional).
@@ -14,25 +14,25 @@ const HeroExternal = (props) => {
       className={`${prefix}--hero-ext`}
       // TODO: do we need a token for the linear gradient?
       style={{
-        backgroundImage: `linear-gradient(rgba(26, 66, 98, 0.8), rgba(26, 66, 98, 0.8)), url(http://www1.wfp.org/sites/default/files/images/yemen-hero-min.jpg)`,
+        backgroundImage: `linear-gradient(rgba(26, 66, 98, 0.8), rgba(26, 66, 98, 0.8)), url(${image})`,
         backgroundPosition: 'center right',
       }}>
       <Wrapper pageWidth="md">
         <div className={`${prefix}--hero-ext__content`}>
-          <h1 className={`${prefix}--hero-ext__heading`}>{props.heading}</h1>
-          <p className={`${prefix}--hero-ext__body-copy`}>{props.body}</p>
+          <h1 className={`${prefix}--hero-ext__heading`}>{title}</h1>
+          <p className={`${prefix}--hero-ext__body-copy`}>{subTitle}</p>
         </div>
-        <div className={`${prefix}--hero-ext__actions`}>
-          <Button allCaps large kind="accent">
-            Accent action
-          </Button>
-          <Button allCaps large kind="inverse">
-            Secondary action
-          </Button>
-        </div>
+        {children}
       </Wrapper>
     </div>
   );
 };
+
+HeroExternal.propTypes = {
+  title: PropTypes.node, 
+  subTitle: PropTypes.node, 
+  image: PropTypes.string, 
+  children: PropTypes.node
+}
 
 export default HeroExternal;

--- a/packages/ui/src/components/Hero/index.js
+++ b/packages/ui/src/components/Hero/index.js
@@ -1,1 +1,2 @@
-export default from './Hero';
+export Hero from './Hero';
+export HeroExternal from './HeroExternal';


### PR DESCRIPTION
Closes @wfp/ui#

Built the new version of the HeroExternal component from the SMP redesign.
Two props are exposed to showcase how they could be used.

#### Changelog

New HeroExternal component
New Sass stylesheet for the HeroExternal

* {{new thing}}

**Changed**

* Imported the new HeroExternal on the Story
* Loaded the new stylesheet

**Removed**

No files have been removed
