### PR TITLE
fix(DatePicker): removed old react-hook-form datepicker

### DIFF
--- a/src/components/DatePicker/DatePicker.stories.js
+++ b/src/components/DatePicker/DatePicker.stories.js
@@ -88,6 +88,7 @@ export const SingleDatePickerNew = (args) => {
   );
 };
 
+/*
 export const SingleDatePickerNewReactHookForm = (args) => {
   const defaultValues = { test: '2020-12-01T11:00:00.000Z' };
   const [focused, setFocused] = useState(false);
@@ -120,7 +121,7 @@ export const SingleDatePickerNewReactHookForm = (args) => {
       />
     </form>
   );
-};
+};*/
 
 export const DateRangePickerDefault = (args) => (
   <DateRangePickerInput {...args} />
@@ -176,6 +177,7 @@ export const DatePickerHookForm = (args) => {
   return (
     <>
       {JSON.stringify(input)}
+      <br />
       <Controller
         control={control}
         name="test"
@@ -238,6 +240,7 @@ export const DatePickerRangeHookForm = (args) => {
   return (
     <>
       {JSON.stringify(datePickerRange)}
+      <br />
       <Controller
         control={control}
         name="datePickerRange"

--- a/src/documentation/Icons/Icons.stories.mdx
+++ b/src/documentation/Icons/Icons.stories.mdx
@@ -2,7 +2,7 @@ import { Meta, Story, Preview } from '@storybook/addon-docs/blocks';
 import Button from '../../components/Button';
 import Blockquote from '../../components/Blockquote';
 import Link from '../../components/Link';
-import IconsComponent from './IconsDocumentation';
+import IconsDocumentation from './IconsDocumentation';
 
 <Meta
   title="Documentation/Core/Icons"
@@ -14,6 +14,6 @@ import IconsComponent from './IconsDocumentation';
   }}
 />
 
-<hr/>
+<hr />
 
-<IconsComponent />
+<IconsDocumentation />

--- a/src/documentation/Icons/IconsDocumentation.js
+++ b/src/documentation/Icons/IconsDocumentation.js
@@ -119,7 +119,7 @@ from '@wfp/icons'`}
 
 const wrapperStyle = { display: 'flex', flexWrap: 'wrap', margin: '0 -0.7em' };
 
-const IconsComponent = () => (
+const IconsDocumentation = () => (
   <>
     <p>
       For Usage please take a look at the{' '}
@@ -221,4 +221,4 @@ const IconsComponent = () => (
   </>
 );
 
-export default IconsComponent;
+export default IconsDocumentation;


### PR DESCRIPTION
This is the fix for the `DatePicker` which is currently not released on `next`.