### PR TITLE
fix: added missing arguments type for 'onRequestClose' method in Moda…

### DIFF
--- a/src/types/Modal/Modal.d.ts
+++ b/src/types/Modal/Modal.d.ts
@@ -25,7 +25,7 @@ declare namespace Modal {
     inPortal?: boolean;
     wide?: boolean;
     modalFooter?: () => void;
-    onRequestClose?: () => void;
+    onRequestClose?: (evt: any, trigger: string) => void;
     onRequestSubmit?: () => void;
     iconDescription?: string;
     className?: string;
@@ -35,5 +35,5 @@ declare namespace Modal {
   }
 }
 
-declare class Modal extends React.Component<Modal.ModalProps> {}
+declare class Modal extends React.Component<Modal.ModalProps> { }
 export = Modal;


### PR DESCRIPTION
**Modal.d.ts**

In the Modal declaration file the 'onRequestClose()' method was missing its arguments types.

#### Changelog

**Changed**

* 'onRequestClose()' method arguments now have their correct types in the Modal declaration file.
