### PR TITLE
Fix/incorrect listitem props interface 

### DIFF
--- a/src/types/List/ListItem.d.ts
+++ b/src/types/List/ListItem.d.ts
@@ -1,9 +1,10 @@
 import * as React from 'react';
 
 declare namespace ListItem  {
-  interface ListItemProps extends React.HTMLProps<ListItem> {
+  interface ListItemProps extends Omit<React.HTMLProps<ListItem>, 'title'> {
     kind?: 'checkmark' | 'cross'
     small?: boolean
+    title?: React.ReactNode
   }
 }
 


### PR DESCRIPTION
#### Changelog

**Changed**

Change `title` prop type from `string` to `ReactNode` in `ListItemProp` interface as it's able to render any element, not just strings.
