### PR TITLE
Fix/incorrect textinput props interface

### DIFF
--- a/src/types/TextInput.d.ts
+++ b/src/types/TextInput.d.ts
@@ -4,7 +4,7 @@ import { InputModes } from './utils';
 
 declare namespace TextInput {
   interface TextInputProps extends React.InputHTMLAttributes<HTMLInputElement> {
-    helperText?: string;
+    helperText?: React.ReactNode;
     labelText?: string;
     defaultValue?: string | number;
     formItemClassName?: string;

--- a/src/types/utils/index.d.ts
+++ b/src/types/utils/index.d.ts
@@ -21,6 +21,7 @@ declare type InputModes = 'none'
  | 'numeric'
  | 'decimal'
  | 'search'
+ | 'password'
  | undefined
 
 declare interface IIcon  {


### PR DESCRIPTION
#### Changelog

**Changed**

- Change `helperText` prop type from `string` to `ReactNode` in `TextInputProp` interface as it's able to render any element, not just strings
- Add 'password' to list of possible values `InputModes` type