### PR TITLE
Fix/incorrect checkbox props interface

### DIFF
--- a/src/types/Checkbox.d.ts
+++ b/src/types/Checkbox.d.ts
@@ -1,11 +1,17 @@
 import * as React from 'react';
 
 declare namespace Checkbox {
-  interface CheckboxProps extends React.InputHTMLAttributes<HTMLInputElement> {
+  interface CheckboxProps
+    extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'onChange'> {
     indeterminate?: boolean;
     labelText?: React.ReactNode;
     hideLabel?: boolean;
     wrapperClassName?: string;
+    onChange?(
+      event: React.ChangeEvent<HTMLInputElement>,
+      checked: boolean,
+      customId: string
+    ): void;
   }
 }
 


### PR DESCRIPTION
#### Changelog

**Changed**

Override inherited `onChange` event handler in `CheckboxProps` interface to match how it's called from inside `Checkbox` component (https://github.com/wfp/designsystem/blob/master/src/components/Checkbox/Checkbox.js#L42)
