### PR TITLE
Fix/incorrect tooltip props interface

### DIFF
--- a/src/types/Tooltip.d.ts
+++ b/src/types/Tooltip.d.ts
@@ -12,6 +12,8 @@ declare namespace Tooltip  {
     modifiers?: []
     usePortal?: boolean
     createRefWrapper?: boolean
+    interactive?: boolean
+    delayHide?: number
   }
 }
 


### PR DESCRIPTION
#### Changelog

**Changed**

Add missing `interactive` and `delayHide` props to `TooltipProps` interface (they're both passed down to https://www.npmjs.com/package/react-popper-tooltip)