### PR TITLE
Fix/incorrect listitem props interface

### DIFF
--- a/src/types/Button.d.ts
+++ b/src/types/Button.d.ts
@@ -2,17 +2,26 @@ import * as React from 'react';
 import { ButtonKind, IIcon } from './utils';
 
 declare namespace Button {
-  interface ButtonProps extends React.ButtonHTMLAttributes<Button> {
+  interface ButtonBaseProps  {
     children?: React.ReactNode;
     small?: boolean;
     large?: boolean;
     kind?: ButtonKind;
-    href?: string;
     icon?: IIcon;
     iconReverse?: boolean;
     // todo: revise iconDescription
     iconDescription?: string;
   }
+
+  interface ButtonButtonProps extends ButtonBaseProps, React.ButtonHTMLAttributes<Button> {
+  }
+
+  interface ButtonLinkProps extends ButtonBaseProps, React.LinkHTMLAttributes<Button> {
+    href?: string;
+    target?: string;
+  }
+
+  type ButtonProps = ButtonButtonProps | ButtonLinkProps
 }
 
 declare class Button extends React.Component<Button.ButtonProps> {}


### PR DESCRIPTION
**Changed**

Split `ButtonProps` interface into button and link variants so that it's typed correctly based on whether `href` prop is passed or not (https://github.com/wfp/designsystem/blob/master/src/components/Button/Button.js#L83-L108)